### PR TITLE
Added sticky option to table rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <!-- Miscellaneous useful icons: -->

--- a/js/composite_object.js
+++ b/js/composite_object.js
@@ -1,7 +1,7 @@
 const compositeObject = class {
     constructor({idx, name=null, xmin=Infinity, xmax=-Infinity, sense=null, anti=null, primaryColor=null, secondaryColor=null,
         scale=1, minOpacity=null, maxOpacity=null, smoothing=null, bpShift=null, shiftOccupancy=0, hideSense=false,
-        hideAnti=false, swap=false, ids=null}) {
+        hideAnti=false, swap=false, sticky=false, ids=null}) {
         this.name = name || "Composite " + idx;
         this.xmin = xmin;
         this.xmax = xmax;
@@ -18,6 +18,7 @@ const compositeObject = class {
         this.hideSense = hideSense;
         this.hideAnti = hideAnti;
         this.swap = swap;
+        this.sticky = sticky;
         this.ids = ids || [];
         this.filesLoaded = this.ids.length
     }
@@ -68,6 +69,10 @@ const compositeObject = class {
 
     changeSwap(swap) {
         this.swap = swap
+    }
+
+    changeSticky(sticky) {
+        this.sticky = sticky
     }
 
     changeBulkSettings(settings) {

--- a/js/composite_row.js
+++ b/js/composite_row.js
@@ -30,7 +30,7 @@ const compositeRow = class {
                 // .classed("drag-icon fa-solid fa-2xl fa-grip-lines", true);
 
         // Add the name column
-        this.nameInput = this.row.append("td").append("div")
+        this.nameInput = this.row.append("td").classed("name-col", true).append("div")
             .classed("name-div", true)
             .attr("contenteditable", true)
             .on("input", function(ev) {
@@ -231,7 +231,7 @@ const compositeRow = class {
                 .classed("sticky-icon fa-solid fa-thumbtack-slash", true);
 
         // Add file upload column
-        const uploadCol = this.row.append("td"),
+        const uploadCol = this.row.append("td").classed("upload-col", true),
             fileInput = uploadCol.append("input")
                 .attr("type", "file")
                 .property("multiple", true)

--- a/js/composite_row.js
+++ b/js/composite_row.js
@@ -213,7 +213,10 @@ const compositeRow = class {
             .on("click", function() {
                 self.compositeDataObj.changeSticky(false);
                 self.row.classed("sticky", false);
-                tableObj.updateStickyRows();
+                const resizeObserver = new ResizeObserver(function() {tableObj.updateStickyRows()});
+                for (const row of tableObj.table.selectAll("tr.composite-row.sticky").nodes()) {
+                    resizeObserver.observe(row)
+                };
                 self.disableSticky()
             })
             .append("i")
@@ -224,7 +227,10 @@ const compositeRow = class {
             .on("click", function() {
                 self.compositeDataObj.changeSticky(true);
                 self.row.classed("sticky", true);
-                tableObj.updateStickyRows();
+                const resizeObserver = new ResizeObserver(function() {tableObj.updateStickyRows()});
+                for (const row of tableObj.table.selectAll("tr.composite-row.sticky").nodes()) {
+                    resizeObserver.observe(row)
+                };
                 self.enableSticky()
             })
             .append("i")

--- a/js/composite_row.js
+++ b/js/composite_row.js
@@ -188,10 +188,9 @@ const compositeRow = class {
                 self.closeEyeIcon()
             })
             .append("i")
-                .classed("hide-icon", true)
-                .classed("eye-open", true)
-                .classed("fas fa-2xl fa-eye", true)
-                .attr("baseProfile", "full");
+                .classed("hide-icon eye-open fas fa-2xl fa-eye", true)
+                .classed("", true)
+                .classed("", true);
         this.eyeClosedIcon = hideCol.append("div")
             .classed("hide-container", true)
             .attr("title", "Show")
@@ -204,10 +203,32 @@ const compositeRow = class {
                 self.openEyeIcon()
             })
             .append("i")
-                .classed("hide-icon", true)
-                .classed("eye-closed", true)
-                .classed("fas fa-2xl fa-eye-slash", true)
-                .attr("title", "Show");
+                .classed("hide-icon eye-closed fas fa-2xl fa-eye-slash", true);
+
+        // Add sticky column
+        const stickyCol = this.row.append("td").classed("sticky-col", true);
+        this.stickyIcon = stickyCol.append("div")
+            .classed("sticky-container", true)
+            .attr("title", "Unsticky")
+            .on("click", function() {
+                self.compositeDataObj.changeSticky(false);
+                self.row.classed("sticky", false);
+                tableObj.updateStickyRows();
+                self.disableSticky()
+            })
+            .append("i")
+                .classed("sticky-icon fa-solid fa-thumbtack", true);
+        this.noStickyIcon = stickyCol.append("div")
+            .classed("sticky-container", true)
+            .attr("title", "Sticky")
+            .on("click", function() {
+                self.compositeDataObj.changeSticky(true);
+                self.row.classed("sticky", true);
+                tableObj.updateStickyRows();
+                self.enableSticky()
+            })
+            .append("i")
+                .classed("sticky-icon fa-solid fa-thumbtack-slash", true);
 
         // Add file upload column
         const uploadCol = this.row.append("td"),
@@ -252,7 +273,8 @@ const compositeRow = class {
                 tableObj.removeRow(self.idx);
                 dataObj.removeCompositeData(self.idx);
                 plotObj.updatePlot();
-                legendObj.updateLegend()
+                legendObj.updateLegend();
+                tableObj.updateStickyRows()
             });
         this.updateInputs()
     }
@@ -273,24 +295,43 @@ const compositeRow = class {
         this.smoothingInput.node().value = this.compositeDataObj.smoothing || "";
         this.shiftInput.node().value = this.compositeDataObj.bpShift || "";
         this.swapIcon.classed("grayed", !this.compositeDataObj.swap);
+        
         if (this.compositeDataObj.hideSense && this.compositeDataObj.hideAnti) {
             this.closeEyeIcon()
         } else {
             this.openEyeIcon()
         };
+        if (this.compositeDataObj.sticky) {
+            this.row.classed("sticky", true);
+            this.enableSticky()
+        } else {
+            this.row.classed("sticky", false);
+            this.disableSticky()
+        };
+
         this.uploadLabel.text(
             this.compositeDataObj.filesLoaded === 1 ? "1 file loaded" : this.compositeDataObj.filesLoaded + " files loaded"
         )
     } 
 
     openEyeIcon() {
-        this.row.select(".eye-open").style("display", null);
-        this.row.select(".eye-closed").style("display", "none")
+        this.eyeOpenIcon.classed("hidden", false);
+        this.eyeClosedIcon.classed("hidden", true)
     }
 
     closeEyeIcon() {
-        this.row.select(".eye-open").style("display", "none");
-        this.row.select(".eye-closed").style("display", null)
+        this.eyeOpenIcon.classed("hidden", true);
+        this.eyeClosedIcon.classed("hidden", false)
+    }
+
+    enableSticky() {
+        this.stickyIcon.classed("hidden", false);
+        this.noStickyIcon.classed("hidden", true)
+    }
+
+    disableSticky() {
+        this.stickyIcon.classed("hidden", true);
+        this.noStickyIcon.classed("hidden", false)
     }
 
     disableDrag() {

--- a/js/composite_table.js
+++ b/js/composite_table.js
@@ -15,7 +15,7 @@ const compositeTable = class {
                 const compositeDataObj = dataObj.addCompositeData({idx: self.nRows});
                 self.addRow(compositeDataObj)
             });
-        this.headerRow.append("th").text("Name");
+        this.headerRow.append("th").classed("name-col", true).text("Name");
         this.headerRow.append("th").text("Color");
         this.headerRow.append("th").text("Scale");
         this.headerRow.append("th").text("Opacity");
@@ -24,7 +24,7 @@ const compositeTable = class {
         this.headerRow.append("th");
         this.headerRow.append("th");
         this.headerRow.append("th");
-        this.headerRow.append("th").text("Upload files");
+        this.headerRow.append("th").classed("upload-col", true).text("Upload files");
         this.headerRow.append("th");
         this.headerRow.append("th");
 

--- a/js/composite_table.js
+++ b/js/composite_table.js
@@ -7,25 +7,26 @@ const compositeTable = class {
 
         this.container = d3.select("#" + elementID)
         const thb = this.container.append("table");
-        const headerRow = thb.append("thead").classed("tableFixHead", true);
+        this.headerRow = thb.append("thead").classed("tableFixHead", true);
         // Insert "Add composite row" in table header
-        this.addRowIcon = headerRow.append("th").append("i")
+        this.addRowIcon = this.headerRow.append("th").append("i")
             .classed("add-row-icon fa-solid fa-2xl fa-circle-plus", true)
             .on("click", function() {
                 const compositeDataObj = dataObj.addCompositeData({idx: self.nRows});
                 self.addRow(compositeDataObj)
             });
-        headerRow.append("th").text("Name");
-        headerRow.append("th").text("Color");
-        headerRow.append("th").text("Scale");
-        headerRow.append("th").text("Opacity");
-        headerRow.append("th").text("Smooth");
-        headerRow.append("th").text("Shift");
-        headerRow.append("th");
-        headerRow.append("th");
-        headerRow.append("th").text("Upload files");
-        headerRow.append("th");
-        headerRow.append("th");
+        this.headerRow.append("th").text("Name");
+        this.headerRow.append("th").text("Color");
+        this.headerRow.append("th").text("Scale");
+        this.headerRow.append("th").text("Opacity");
+        this.headerRow.append("th").text("Smooth");
+        this.headerRow.append("th").text("Shift");
+        this.headerRow.append("th");
+        this.headerRow.append("th");
+        this.headerRow.append("th");
+        this.headerRow.append("th").text("Upload files");
+        this.headerRow.append("th");
+        this.headerRow.append("th");
 
         this.table = thb.append("tbody");
 
@@ -58,6 +59,9 @@ const compositeTable = class {
         for (const i in this.rows) {
             this.rows[i].updateIndex(i)
         };
+
+        // Update sticky rows
+        this.updateStickyRows()
     }
 
     insertRowAfter(dragIdx, dropIdx) {
@@ -72,7 +76,10 @@ const compositeTable = class {
         // Update row indices
         for (const i in this.rows) {
             this.rows[i].updateIndex(parseInt(i))
-        }
+        };
+
+        // Update sticky rows
+        this.updateStickyRows()
     }
 
     removeRow(idx) {
@@ -96,6 +103,15 @@ const compositeTable = class {
         this.rows = [];
         this.nRows = 0;
         this.table.selectAll(".composite-row").remove()
+    }
+
+    updateStickyRows() {
+        let {height: y} = this.headerRow.node().getBoundingClientRect();
+        this.table.selectAll("tr.composite-row.sticky")
+            .each(function() {
+                d3.select(this).style("top", y + "px");
+                y += this.getBoundingClientRect().height
+            })
     }
 };
 

--- a/js/data_object.js
+++ b/js/data_object.js
@@ -82,11 +82,11 @@ const dataObject = class {
 
     addCompositeData({idx, name=null, xmin=Infinity, xmax=-Infinity, sense=null, anti=null, primaryColor=null,
         secondaryColor=null, scale=1, minOpacity=null, maxOpacity=null, smoothing=null, bpShift=null, shiftOccupancy=0,
-        hideSense=false, hideAnti=false, swap=false, ids=null}) {
+        hideSense=false, hideAnti=false, swap=false, sticky=false, ids=null}) {
         const compositeDataObj = new compositeObject({idx, name: name, xmin: xmin, xmax: xmax, sense: sense, anti: anti,
             primaryColor: primaryColor, secondaryColor: secondaryColor, scale: scale, minOpacity: minOpacity,
             maxOpacity: maxOpacity, smoothing: smoothing, bpShift: bpShift, shiftOccupancy: shiftOccupancy,
-            hideSense: hideSense, hideAnti: hideAnti, swap: swap, ids: ids});
+            hideSense: hideSense, hideAnti: hideAnti, swap: swap, sticky: sticky, ids: ids});
         this.compositeData.push(compositeDataObj);
         this.legendOrder.push(idx);
 

--- a/style.css
+++ b/style.css
@@ -344,7 +344,7 @@
     border-right: 1px solid #8888FF !important;
 }
 
-.file-drag-highlight {
+.file-drag-highlight td {
     background-color: #CCCCCC;
 }
 

--- a/style.css
+++ b/style.css
@@ -285,7 +285,7 @@
 #composite-table th {
     text-align: center;
     border-top: 1px solid black;
-    border-bottom: 1px solid black;
+    border-bottom: .5px solid black;
 }
 
 #composite-table th:nth-child(1) {
@@ -296,7 +296,7 @@
     text-align: left;
 }
 
-#composite-table th:nth-child(13) {
+#composite-table th:last-child {
     border-right: 1px solid black;
 }
 
@@ -317,6 +317,11 @@
 }
 
 #composite-table td {
+    border-top: .5px solid black;
+    border-bottom: .5px solid black;
+}
+
+#composite-table tr:last-child td {
     border-bottom: 1px solid black;
 }
 
@@ -328,20 +333,25 @@
     text-align: left;
 }
 
-#composite-table td:nth-child(13) {
+#composite-table td:last-child {
     border-right: 1px solid black;
 }
 
-.mouse-highlight td {
-    border-bottom: 1px solid #8888FF !important;
+#composite-table tr.mouse-highlight td {
+    border-top: .5px solid #8888FF;
+    border-bottom: .5px solid #8888FF;
 }
 
-.mouse-highlight td:nth-child(1) {
-    border-left: 1px solid #8888FF !important;
+#composite-table tr:last-child.mouse-highlight td {
+    border-bottom: 1px solid #8888FF;
 }
 
-.mouse-highlight td:nth-child(13) {
-    border-right: 1px solid #8888FF !important;
+#composite-table tr.mouse-highlight td:nth-child(1) {
+    border-left: 1px solid #8888FF;
+}
+
+#composite-table tr.mouse-highlight td:nth-child(13) {
+    border-right: 1px solid #8888FF;
 }
 
 .file-drag-highlight td {

--- a/style.css
+++ b/style.css
@@ -449,6 +449,10 @@ input[type=range] {
     width: 100%;
 }
 
+.fa-thumbtack {
+    color: #0088FF;
+}
+
 .upload-button {
     width: 35px;
     height: 30px;

--- a/style.css
+++ b/style.css
@@ -350,7 +350,7 @@
     border-left: 1px solid #8888FF;
 }
 
-#composite-table tr.mouse-highlight td:nth-child(13) {
+#composite-table tr.mouse-highlight td:last-child {
     border-right: 1px solid #8888FF;
 }
 

--- a/style.css
+++ b/style.css
@@ -288,11 +288,15 @@
     border-bottom: .5px solid black;
 }
 
-#composite-table th:nth-child(1) {
+#composite-table th:first-child {
     border-left: 1px solid black;
 }
 
-#composite-table th:nth-child(2) {
+#composite-table th.name-col {
+    text-align: left;
+}
+
+#composite-table th.upload-col {
     text-align: left;
 }
 
@@ -326,11 +330,15 @@
     border-bottom: 1px solid black;
 }
 
-#composite-table td:nth-child(1) {
+#composite-table td:first-child {
     border-left: 1px solid black;
 }
 
-#composite-table td:nth-child(2) {
+#composite-table td.name-col {
+    text-align: left;
+}
+
+#composite-table td.upload-col {
     text-align: left;
 }
 
@@ -347,7 +355,7 @@
     border-bottom: 1px solid #8888FF;
 }
 
-#composite-table tr.mouse-highlight td:nth-child(1) {
+#composite-table tr.mouse-highlight td:first-child {
     border-left: 1px solid #8888FF;
 }
 

--- a/style.css
+++ b/style.css
@@ -256,18 +256,6 @@
     padding-top: 15px;
 }
 
-.tableFixHead {
-    overflow: auto;
-    font-size: 16px;
-    height: 50px;
-    width: 100%;
-    background: #eee;
-    border: 1px solid black;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-}
-
 #composite-table {
     width: 100%;
     margin-top: 10px;
@@ -275,6 +263,41 @@
 
 #composite-table table {
     width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+#composite-table thead {
+    overflow: auto;
+    font-size: 16px;
+    height: 50px;
+    width: 100%;
+    background: #eee;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+#composite-table th, td {
+    padding: 8px 16px;
+}
+
+#composite-table th {
+    text-align: center;
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
+}
+
+#composite-table th:nth-child(1) {
+    border-left: 1px solid black;
+}
+
+#composite-table th:nth-child(2) {
+    text-align: left;
+}
+
+#composite-table th:nth-child(13) {
+    border-right: 1px solid black;
 }
 
 #composite-table tbody {
@@ -285,31 +308,40 @@
     cursor: grab;
     height: 50px;
     width: 100%;
-    border: 1px solid black;
+    background: #FFFFFF;
 }
 
-#composite-table th, td {
-    padding: 8px 16px;
+#composite-table tr.sticky {
+    position: sticky;
+    z-index: 1;
 }
 
-#composite-table th:nth-child(1) {
-    text-align: center;
+#composite-table td {
+    border-bottom: 1px solid black;
 }
 
 #composite-table td:nth-child(1) {
-    text-align: center;
+    border-left: 1px solid black;
 }
 
-#composite-table th:nth-child(n+3):nth-child(-n+7) {
-    text-align: center;
+#composite-table td:nth-child(2) {
+    text-align: left;
 }
 
-#composite-table td:nth-child(n+3):nth-child(-n+7) {
-    text-align: center;
+#composite-table td:nth-child(13) {
+    border-right: 1px solid black;
 }
 
-.mouse-highlight {
-    border: 3px solid #8888FF !important;
+.mouse-highlight td {
+    border-bottom: 1px solid #8888FF !important;
+}
+
+.mouse-highlight td:nth-child(1) {
+    border-left: 1px solid #8888FF !important;
+}
+
+.mouse-highlight td:nth-child(13) {
+    border-right: 1px solid #8888FF !important;
 }
 
 .file-drag-highlight {
@@ -385,6 +417,16 @@ input[type=range] {
 }
 
 .hide-icon {
+    width: 100%;
+}
+
+.sticky-container {
+    width: 20px;
+    text-align: center;
+    cursor: pointer;
+}
+
+.sticky-icon {
     width: 100%;
 }
 

--- a/style.css
+++ b/style.css
@@ -317,6 +317,7 @@
 }
 
 #composite-table td {
+    text-align: center;
     border-top: .5px solid black;
     border-bottom: .5px solid black;
 }


### PR DESCRIPTION
On Safari, dragging one of the sticky rows causes the ghost image to include elements from other rows. It still works as expected though. Also this does not happen in Chrome or Firefox